### PR TITLE
✨feat: Site조회 구현 / 응답 공통로직 구현

### DIFF
--- a/src/main/java/greenjangtanji/yeosuro/global/aws/config/S3Config.java
+++ b/src/main/java/greenjangtanji/yeosuro/global/aws/config/S3Config.java
@@ -10,10 +10,10 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class S3Config {
-    @Value("${cloud.aws.credentials.access-key}")
+    @Value("${cloud.aws.credentials.accessKey}")
     private String accessKey;
 
-    @Value("${cloud.aws.credentials.secret-key}")
+    @Value("${cloud.aws.credentials.secretKey}")
     private String secretKey;
 
     @Value("${cloud.aws.region.static}")

--- a/src/main/java/greenjangtanji/yeosuro/global/handler/ApiResponse.java
+++ b/src/main/java/greenjangtanji/yeosuro/global/handler/ApiResponse.java
@@ -1,0 +1,20 @@
+package greenjangtanji.yeosuro.global.handler;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class ApiResponse<T> {
+
+    private int status;
+    private String message;
+    private T data;
+
+    public ApiResponse(int status, String message, T data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+}
+

--- a/src/main/java/greenjangtanji/yeosuro/global/handler/GlobalResponseHandler.java
+++ b/src/main/java/greenjangtanji/yeosuro/global/handler/GlobalResponseHandler.java
@@ -1,0 +1,46 @@
+package greenjangtanji.yeosuro.global.handler;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalResponseHandler implements ResponseBodyAdvice<Object> {
+
+    @Autowired
+    private HttpServletResponse httpServletResponse;
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true; //모든 컨트롤러에 적용
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request,
+                                  ServerHttpResponse response) {
+
+        HttpStatus status = HttpStatus.resolve(httpServletResponse.getStatus());
+        if(status == null){
+            status = HttpStatus.OK;
+        }
+
+        if (body instanceof Map && ((Map<?, ?>) body).containsKey("status")) {
+            return body;
+        }
+
+        return new ApiResponse<>(status.value(), status.getReasonPhrase(), body);
+    }
+}

--- a/src/main/java/greenjangtanji/yeosuro/site/controller/SiteController.java
+++ b/src/main/java/greenjangtanji/yeosuro/site/controller/SiteController.java
@@ -1,10 +1,52 @@
 package greenjangtanji.yeosuro.site.controller;
 
+import greenjangtanji.yeosuro.plan.service.PlanService;
+import greenjangtanji.yeosuro.site.dto.SiteDto;
+import greenjangtanji.yeosuro.site.entity.Site;
+import greenjangtanji.yeosuro.site.mapper.SiteMapper;
+import greenjangtanji.yeosuro.site.service.SiteService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/v1/sites")
 public class SiteController {
+
+    private final SiteService siteService;
+    private final PlanService planService;
+    private final SiteMapper siteMapper;
+
+    @Autowired
+    public SiteController(SiteService siteService, PlanService planService, SiteMapper siteMapper) {
+        this.siteService = siteService;
+        this.planService = planService;
+        this.siteMapper = siteMapper;
+    }
+
+
+    //사이트 개별 조회
+    @GetMapping(value = {"/{siteId}"})
+    public ResponseEntity<?> getSite(@PathVariable(value = "siteId") Long id) {
+        Site site = siteService.getSite(id);
+
+        SiteDto.SiteResponseDtoNoDate siteResponseDtoNoDate = siteMapper.siteToSiteResponseDtoNoDate(site);
+
+        return new ResponseEntity<>(siteResponseDtoNoDate, HttpStatus.OK);
+    }
+
+    //모든 사이트 조회
+    @GetMapping(value = {"/", ""})
+    public ResponseEntity<?> getSites(){
+        List<Site> allSites = siteService.getAllSites();
+        List<SiteDto.SiteResponseDtoNoDate> siteResponseDtoNoDateList = siteMapper.siteToSiteResponseDtoNoDateList(allSites);
+        return new ResponseEntity<>(siteResponseDtoNoDateList, HttpStatus.OK);
+    }
 
 }

--- a/src/main/java/greenjangtanji/yeosuro/site/controller/SiteController.java
+++ b/src/main/java/greenjangtanji/yeosuro/site/controller/SiteController.java
@@ -30,14 +30,11 @@ public class SiteController {
         this.siteMapper = siteMapper;
     }
 
-
     //사이트 개별 조회
     @GetMapping(value = {"/{siteId}"})
     public ResponseEntity<?> getSite(@PathVariable(value = "siteId") Long id) {
         Site site = siteService.getSite(id);
-
         SiteDto.SiteResponseDtoNoDate siteResponseDtoNoDate = siteMapper.siteToSiteResponseDtoNoDate(site);
-
         return new ResponseEntity<>(siteResponseDtoNoDate, HttpStatus.OK);
     }
 

--- a/src/main/java/greenjangtanji/yeosuro/site/dto/SiteDto.java
+++ b/src/main/java/greenjangtanji/yeosuro/site/dto/SiteDto.java
@@ -31,4 +31,16 @@ public class SiteDto {
         private String address;
         private Long visitDate;
     }
+
+    // Site 개별 조회에서 사용 -> 사용자가 장소만 검색하는 경우
+    @Getter
+    @Setter
+    public static class SiteResponseDtoNoDate{
+        private Long id;
+        private String category;
+        private String memo;
+        private String latitude;
+        private String longitude;
+        private String address;
+    }
 }

--- a/src/main/java/greenjangtanji/yeosuro/site/mapper/SiteMapper.java
+++ b/src/main/java/greenjangtanji/yeosuro/site/mapper/SiteMapper.java
@@ -1,11 +1,19 @@
 package greenjangtanji.yeosuro.site.mapper;
 
+import greenjangtanji.yeosuro.plan.dto.PlanDto;
+import greenjangtanji.yeosuro.plan.entity.Plan;
 import greenjangtanji.yeosuro.site.dto.SiteDto;
 import greenjangtanji.yeosuro.site.entity.Site;
 import org.mapstruct.Mapper;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface SiteMapper {
 
     SiteDto.SiteResponseDto siteToSiteResponseDto(Site site);
+
+    SiteDto.SiteResponseDtoNoDate siteToSiteResponseDtoNoDate(Site site);
+
+    List<SiteDto.SiteResponseDtoNoDate> siteToSiteResponseDtoNoDateList(List<Site> sites);
 }

--- a/src/main/java/greenjangtanji/yeosuro/site/service/SiteService.java
+++ b/src/main/java/greenjangtanji/yeosuro/site/service/SiteService.java
@@ -1,4 +1,27 @@
 package greenjangtanji.yeosuro.site.service;
 
+import greenjangtanji.yeosuro.site.entity.Site;
+import greenjangtanji.yeosuro.site.repository.SiteRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
 public class SiteService {
+
+    private final SiteRepository siteRepository;
+
+    @Autowired
+    public SiteService(SiteRepository siteRepository) {
+        this.siteRepository = siteRepository;
+    }
+
+    public List<Site> getAllSites(){
+        return siteRepository.findAll();
+    }
+
+    public Site getSite(Long siteId){
+        return siteRepository.findById(siteId).orElseThrow(() -> new RuntimeException("Site를 찾을수 없습니다."));
+    }
 }


### PR DESCRIPTION
- Site 조회구현
- 응답 공통 로직 구현

응답 예시

1. 정상응답
```
{
    "status": 200,
    "message": "OK",
    "data": {
        "id": 1,
        "category": "카테고리",
        "memo": "메모입니다.",
        "latitude": "111",
        "longitude": "222",
        "address": "어디어디"
    }
}
```

data의 경우 object / List 형태에 맞추어 표출됨

2. 에러응답
```
{
    "error": "Not Found",
    "message": "Endpoint '/place/:placeId/review' not found",
    "status": 404
}
```