### PR TITLE
✨feat: 게시글/댓글 좋아요 및 좋아요 취소 기능 구현 #41

### DIFF
--- a/src/main/java/greenjangtanji/yeosuro/feed/controller/FeedController.java
+++ b/src/main/java/greenjangtanji/yeosuro/feed/controller/FeedController.java
@@ -1,16 +1,12 @@
 package greenjangtanji.yeosuro.feed.controller;
 
-import greenjangtanji.yeosuro.feed.dto.FeedListResponseDto;
 import greenjangtanji.yeosuro.feed.dto.FeedRequestDto;
 import greenjangtanji.yeosuro.feed.dto.FeedResponseDto;
-import greenjangtanji.yeosuro.feed.entity.Feed;
 import greenjangtanji.yeosuro.feed.entity.FeedCategory;
 import greenjangtanji.yeosuro.feed.service.FeedService;
 import greenjangtanji.yeosuro.global.exception.BusinessLogicException;
 import greenjangtanji.yeosuro.global.exception.ExceptionCode;
-import greenjangtanji.yeosuro.image.entity.ImageType;
 import greenjangtanji.yeosuro.image.service.ImageService;
-import greenjangtanji.yeosuro.user.dto.UserResponseDto;
 import greenjangtanji.yeosuro.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -67,7 +63,7 @@ public class FeedController {
     //특정 게시글 조회
     @GetMapping("{feed-id}")
     public ResponseEntity getFeed (@PathVariable("feed-id") Long feedId){
-        FeedResponseDto feedResponseDto = feedService.findById(feedId);
+        FeedResponseDto feedResponseDto = feedService.findFeedById(feedId);
 
         return new ResponseEntity<>(feedResponseDto, HttpStatus.OK);
 

--- a/src/main/java/greenjangtanji/yeosuro/feed/dto/FeedListResponseDto.java
+++ b/src/main/java/greenjangtanji/yeosuro/feed/dto/FeedListResponseDto.java
@@ -16,7 +16,7 @@ public class FeedListResponseDto {
     private Long id;
     private String title;
     private List<String> imageUrls;
-    private Long likesCount;
+    private int likesCount;
     private int view;
     private String content;
     private int repliesCount;
@@ -32,7 +32,7 @@ public class FeedListResponseDto {
         this.id = feed.getId();
         this.title = feed.getTitle();
         this.imageUrls = imageUrls;
-        this.likesCount = feed.getLikesCount();
+        this.likesCount = feed.getFeedLikesCount();
         this.view = feed.getView();
         this.content = feed.getContent();
         this.repliesCount = feed.getRepliesCount();

--- a/src/main/java/greenjangtanji/yeosuro/feed/dto/FeedResponseDto.java
+++ b/src/main/java/greenjangtanji/yeosuro/feed/dto/FeedResponseDto.java
@@ -16,7 +16,7 @@ public class FeedResponseDto {
     private String content;
     private List<String> imageUrls;
     private int view;
-    private Long likesCount;
+    private int likesCount;
     private int repliesCount;
     private String feedCategory;
     private LocalDateTime createAt;
@@ -33,7 +33,7 @@ public class FeedResponseDto {
         this.content = feed.getContent();
         this.imageUrls = imageUrls;
         this.view = feed.getView();
-        this.likesCount = feed.getLikesCount();
+        this.likesCount = feed.getFeedLikesCount();
         this.repliesCount = feed.getRepliesCount();
         this.feedCategory = String.valueOf(feed.getFeedCategory());
         this.createAt = feed.getCreateAt();

--- a/src/main/java/greenjangtanji/yeosuro/feed/entity/Feed.java
+++ b/src/main/java/greenjangtanji/yeosuro/feed/entity/Feed.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonBackReference;
 import greenjangtanji.yeosuro.feed.dto.FeedRequestDto;
 import greenjangtanji.yeosuro.global.config.Timestamped;
 import greenjangtanji.yeosuro.image.entity.Image;
+import greenjangtanji.yeosuro.likes.entity.FeedLikes;
 import greenjangtanji.yeosuro.reply.entity.Reply;
 import greenjangtanji.yeosuro.user.entity.User;
 import jakarta.persistence.*;
@@ -31,8 +32,6 @@ public class Feed extends Timestamped {
     @Column(nullable = false)
     private int view = 1;
 
-    private Long LikesCount = 1L;
-
     @Enumerated(EnumType.STRING)
     private FeedCategory feedCategory;
 
@@ -47,6 +46,8 @@ public class Feed extends Timestamped {
     @OneToMany(mappedBy = "referenceId", fetch = FetchType.LAZY)
     private List<Image> images = new ArrayList<>();
 
+    @OneToMany(mappedBy = "feed", cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
+    private List<FeedLikes> feedLikes  = new ArrayList<>();
 
     public static Feed createFeed (FeedRequestDto.Post requestDto, User user){
         Feed feed = new Feed();
@@ -69,5 +70,7 @@ public class Feed extends Timestamped {
     public int getRepliesCount() {
         return replies.size();
     }
+
+    public int getFeedLikesCount () { return feedLikes.size(); }
 
 }

--- a/src/main/java/greenjangtanji/yeosuro/global/exception/ExceptionCode.java
+++ b/src/main/java/greenjangtanji/yeosuro/global/exception/ExceptionCode.java
@@ -8,11 +8,13 @@ public enum ExceptionCode {
     JWT_TOKEN_ERROR (401, "토큰 오류로 UserId 추출 불가"),
     BOARD_NOT_FOUND(404, "게시글 정보를 찾을 수 없음"),
     REPLY_NOT_FOUND (404, "댓글 정보를 찾을 수 없음"),
+    LIKES_NOT_FOUND (404, "좋아요 정보를 찾을 수 없음"),
     CATEGORY_NOT_FOUND (404, "게시글 카테고리 정보를 찾을 수 없음"),
     USER_NOT_FOUND(404, "유저 정보를 찾을 수 없음"),
     USER_NOT_ACTIVE(403, "탈퇴한 회원입니다."),
     DUPLICATE_EMAIL_ERROR (409, "이메일 중복"),
     DUPLICATE_NICKNAME_ERROR (409, "닉네임 중복"),
+    DUPLICATE_ERROR (409, "중복된 요청"),
 
     FILE_UPLOAD_ERROR(413, "파일 업로드 실패"),
     FILE_DELETE_ERROR(500, "파일 삭제 실패"),

--- a/src/main/java/greenjangtanji/yeosuro/likes/controller/LikeController.java
+++ b/src/main/java/greenjangtanji/yeosuro/likes/controller/LikeController.java
@@ -1,0 +1,66 @@
+package greenjangtanji.yeosuro.likes.controller;
+
+import greenjangtanji.yeosuro.likes.service.LikeService;
+import greenjangtanji.yeosuro.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+@Validated
+public class LikeController {
+
+    private final UserService userService;
+    private final LikeService likeService;
+
+    //게시글 좋아요
+    @PostMapping("/feeds/{feed-id}/likes")
+    public ResponseEntity createFeedLikes (@PathVariable("feed-id") Long feedId,
+                                       Authentication authentication){
+
+        Long userId = userService.extractUserId(authentication);
+        likeService.createFeedLike(userId, feedId);
+        return ResponseEntity.ok().build();
+    }
+
+    //댓글 좋아요
+    @PostMapping("/feeds/replies/{reply-id}/likes")
+    public ResponseEntity createReplyLikes (@PathVariable("reply-id") Long replyId,
+                                            Authentication authentication){
+        Long userId = userService.extractUserId(authentication);
+        likeService.createReplyLike(userId, replyId);
+        return ResponseEntity.ok().build();
+    }
+
+    //여정 후기 좋아요
+    //TODO : 여정 후기 좋아요 구현
+
+    //게시글 좋아요 취소
+    @DeleteMapping("/feeds/{feed-id}/likes")
+    public ResponseEntity deleteFeedLikes (@PathVariable("feed-id") Long feedId,
+                                           Authentication authentication){
+        Long userId = userService.extractUserId(authentication);
+        likeService.deleteFeedLike(userId, feedId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    //댓글 좋아요 취소
+    @DeleteMapping("/feeds/replies/{reply-id}/likes")
+    public ResponseEntity deleteReplyLikes(@PathVariable("reply-id") Long replyId,
+                                            Authentication authentication){
+        Long userId = userService.extractUserId(authentication);
+        likeService.deleteReplyLike(userId, replyId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    //여정 후기 좋아요 취소
+    //TODO : 여정 후기 좋아요 취소 구현
+}

--- a/src/main/java/greenjangtanji/yeosuro/likes/entity/FeedLikes.java
+++ b/src/main/java/greenjangtanji/yeosuro/likes/entity/FeedLikes.java
@@ -1,0 +1,32 @@
+package greenjangtanji.yeosuro.likes.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import greenjangtanji.yeosuro.feed.entity.Feed;
+import greenjangtanji.yeosuro.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@Entity(name = "feed_likes")
+public class FeedLikes {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    @JsonBackReference
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "feed_id")
+    @JsonBackReference
+    private Feed feed;
+}

--- a/src/main/java/greenjangtanji/yeosuro/likes/entity/ReplyLikes.java
+++ b/src/main/java/greenjangtanji/yeosuro/likes/entity/ReplyLikes.java
@@ -1,0 +1,33 @@
+package greenjangtanji.yeosuro.likes.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import greenjangtanji.yeosuro.feed.entity.Feed;
+import greenjangtanji.yeosuro.reply.entity.Reply;
+import greenjangtanji.yeosuro.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@Entity(name = "reply_likes")
+public class ReplyLikes {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    @JsonBackReference
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "reply_id")
+    @JsonBackReference
+    private Reply reply;
+}

--- a/src/main/java/greenjangtanji/yeosuro/likes/repository/FeedLikeRepository.java
+++ b/src/main/java/greenjangtanji/yeosuro/likes/repository/FeedLikeRepository.java
@@ -1,0 +1,12 @@
+package greenjangtanji.yeosuro.likes.repository;
+
+import greenjangtanji.yeosuro.feed.entity.Feed;
+import greenjangtanji.yeosuro.likes.entity.FeedLikes;
+import greenjangtanji.yeosuro.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FeedLikeRepository extends JpaRepository<FeedLikes, Long> {
+    Optional <FeedLikes> findByUserAndFeed (User user, Feed feed);
+}

--- a/src/main/java/greenjangtanji/yeosuro/likes/repository/ReplyLikeRepository.java
+++ b/src/main/java/greenjangtanji/yeosuro/likes/repository/ReplyLikeRepository.java
@@ -1,0 +1,12 @@
+package greenjangtanji.yeosuro.likes.repository;
+
+import greenjangtanji.yeosuro.likes.entity.ReplyLikes;
+import greenjangtanji.yeosuro.reply.entity.Reply;
+import greenjangtanji.yeosuro.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReplyLikeRepository extends JpaRepository<ReplyLikes, Long> {
+    Optional<ReplyLikes> findByUserAndReply (User user, Reply reply);
+}

--- a/src/main/java/greenjangtanji/yeosuro/likes/service/LikeService.java
+++ b/src/main/java/greenjangtanji/yeosuro/likes/service/LikeService.java
@@ -1,0 +1,109 @@
+package greenjangtanji.yeosuro.likes.service;
+
+import greenjangtanji.yeosuro.feed.entity.Feed;
+import greenjangtanji.yeosuro.feed.service.FeedService;
+import greenjangtanji.yeosuro.global.exception.BusinessLogicException;
+import greenjangtanji.yeosuro.global.exception.ExceptionCode;
+import greenjangtanji.yeosuro.likes.entity.FeedLikes;
+import greenjangtanji.yeosuro.likes.entity.ReplyLikes;
+import greenjangtanji.yeosuro.likes.repository.FeedLikeRepository;
+import greenjangtanji.yeosuro.likes.repository.ReplyLikeRepository;
+import greenjangtanji.yeosuro.reply.entity.Reply;
+import greenjangtanji.yeosuro.reply.service.ReplyService;
+import greenjangtanji.yeosuro.user.entity.User;
+import greenjangtanji.yeosuro.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final FeedLikeRepository feedLikeRepository;
+    private final ReplyLikeRepository replyLikeRepository;
+    private final FeedService feedService;
+    private final ReplyService replyService;
+    private final UserService userService;
+
+    /**
+     * 게시글 좋아요
+     * @param userId
+     * @param feedId
+     */
+    public void createFeedLike (Long userId, Long feedId) {
+        User user = userService.getUserInfo(userId);
+        Feed feed = feedService.checkFeed(feedId);
+        Optional<FeedLikes> feedLikesOptional = feedLikeRepository.findByUserAndFeed(user, feed);
+
+        if (feedLikesOptional.isPresent()){
+            throw new BusinessLogicException(ExceptionCode.DUPLICATE_ERROR);
+        }else {
+            FeedLikes feedLikes = FeedLikes.builder()
+                    .user(user)
+                    .feed(feed)
+                    .build();
+            feedLikeRepository.save(feedLikes);
+        }
+    }
+
+    /**
+     * 댓글 좋아요
+     * @param userId
+     * @param replyId
+     */
+    public void createReplyLike (Long userId, Long replyId) {
+        User user = userService.getUserInfo(userId);
+        Reply reply = replyService.checkReply(replyId);
+        Optional<ReplyLikes> replyLikesOptional = replyLikeRepository.findByUserAndReply(user, reply);
+
+        if (replyLikesOptional.isPresent()){
+            throw new BusinessLogicException(ExceptionCode.DUPLICATE_ERROR);
+        }else {
+            ReplyLikes replyLikes = ReplyLikes.builder()
+                    .user(user)
+                    .reply(reply)
+                    .build();
+
+            replyLikeRepository.save(replyLikes);
+        }
+    }
+
+    //여정 후기 좋아요
+    //TODO : 여정 후기 좋아요 비즈니스 로직 구현
+
+    /**
+     * 게시글 좋아요 취소
+     * @param userId
+     * @param feedId
+     */
+    public void deleteFeedLike (Long userId, Long feedId){
+        User user = userService.getUserInfo(userId);
+        Feed feed = feedService.checkFeed(feedId);
+        FeedLikes feedLikes = feedLikeRepository.findByUserAndFeed(user, feed).orElseThrow(
+                () -> new BusinessLogicException(ExceptionCode.LIKES_NOT_FOUND));
+
+        feedLikeRepository.deleteById(feedLikes.getId());
+    }
+
+    /**
+     * 댓글 좋아요 취소
+     * @param userId
+     * @param replyId
+     */
+    public void deleteReplyLike (Long userId, Long replyId){
+        User user = userService.getUserInfo(userId);
+        Reply reply = replyService.checkReply(replyId);
+        ReplyLikes replyLikes = replyLikeRepository.findByUserAndReply(user, reply).orElseThrow(
+                () -> new BusinessLogicException(ExceptionCode.LIKES_NOT_FOUND));
+
+        replyLikeRepository.deleteById(replyLikes.getId());
+    }
+
+    //여정 후기 좋아요 취소
+    //TODO : 여정 후기 좋아요 취소 비즈니스 로직 구현
+
+}

--- a/src/main/java/greenjangtanji/yeosuro/reply/controller/ReplyController.java
+++ b/src/main/java/greenjangtanji/yeosuro/reply/controller/ReplyController.java
@@ -1,7 +1,5 @@
 package greenjangtanji.yeosuro.reply.controller;
 
-import greenjangtanji.yeosuro.image.entity.ImageType;
-import greenjangtanji.yeosuro.image.service.ImageService;
 import greenjangtanji.yeosuro.reply.dto.ReplyRequestDto;
 import greenjangtanji.yeosuro.reply.dto.ReplyResponseDto;
 import greenjangtanji.yeosuro.reply.entity.Reply;
@@ -27,7 +25,6 @@ public class ReplyController {
 
     private final ReplyService replyService;
     private final UserService userService;
-    private final ImageService imageService;
 
     //댓글 생성
     @PostMapping()

--- a/src/main/java/greenjangtanji/yeosuro/reply/dto/ReplyResponseDto.java
+++ b/src/main/java/greenjangtanji/yeosuro/reply/dto/ReplyResponseDto.java
@@ -13,6 +13,7 @@ public class ReplyResponseDto {
     private Long id;
     private Long feedID;
     private String content;
+    private int likesCount;
     private LocalDateTime createAt;
     private LocalDateTime modifiedAt;
     private Long memberID;
@@ -24,6 +25,7 @@ public class ReplyResponseDto {
         this.id = reply.getId();
         this.feedID = reply.getFeed().getId();
         this.content = reply.getContent();
+        this.likesCount = reply.getReplyLikesCount();
         this.createAt = reply.getCreateAt();
         this.modifiedAt = reply.getModifiedAt();
         this.memberID = reply.getUser().getId();

--- a/src/main/java/greenjangtanji/yeosuro/reply/entity/Reply.java
+++ b/src/main/java/greenjangtanji/yeosuro/reply/entity/Reply.java
@@ -3,11 +3,15 @@ package greenjangtanji.yeosuro.reply.entity;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import greenjangtanji.yeosuro.feed.entity.Feed;
 import greenjangtanji.yeosuro.global.config.Timestamped;
+import greenjangtanji.yeosuro.likes.entity.ReplyLikes;
 import greenjangtanji.yeosuro.reply.dto.ReplyRequestDto;
 import greenjangtanji.yeosuro.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor
 @Getter
@@ -22,8 +26,6 @@ public class Reply extends Timestamped {
     @Column(nullable = false)
     private String content;
 
-    private long LikesCount;
-
 
     @ManyToOne
     @JoinColumn(name = "user_id")
@@ -35,6 +37,9 @@ public class Reply extends Timestamped {
     @JoinColumn(name = "feed_id")
     @JsonBackReference
     private Feed feed;
+
+    @OneToMany(mappedBy = "reply", cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
+    private List<ReplyLikes> replyLikes  = new ArrayList<>();
 
 
     public static Reply createReply (ReplyRequestDto.Post requestDto, User user, Feed feed){
@@ -48,4 +53,6 @@ public class Reply extends Timestamped {
     public void updateReply (String content){
         this.content = content;
     }
+    public int getReplyLikesCount () { return replyLikes.size();}
+
 }

--- a/src/main/java/greenjangtanji/yeosuro/reply/service/ReplyService.java
+++ b/src/main/java/greenjangtanji/yeosuro/reply/service/ReplyService.java
@@ -4,8 +4,6 @@ import greenjangtanji.yeosuro.feed.entity.Feed;
 import greenjangtanji.yeosuro.feed.repository.FeedRepository;
 import greenjangtanji.yeosuro.global.exception.BusinessLogicException;
 import greenjangtanji.yeosuro.global.exception.ExceptionCode;
-import greenjangtanji.yeosuro.image.entity.ImageType;
-import greenjangtanji.yeosuro.image.service.ImageService;
 import greenjangtanji.yeosuro.reply.dto.ReplyResponseDto;
 import greenjangtanji.yeosuro.user.entity.User;
 import greenjangtanji.yeosuro.reply.dto.ReplyRequestDto;
@@ -58,9 +56,8 @@ public class ReplyService {
 
     //댓글 수정
     @Transactional
-    public Reply updateReply (Long id, ReplyRequestDto.Patch requestDto){
-        Reply existingReply = replyRepository.findById(id).orElseThrow(
-                () -> new BusinessLogicException(ExceptionCode.REPLY_NOT_FOUND));
+    public Reply updateReply (Long replyId, ReplyRequestDto.Patch requestDto){
+        Reply existingReply = checkReply(replyId);
 
         existingReply.updateReply(requestDto.getContent());
         return existingReply;
@@ -68,11 +65,18 @@ public class ReplyService {
 
     //댓글 삭제
     @Transactional
-    public Long deleteReply (Long id){
-        Reply existingReply = replyRepository.findById(id).orElseThrow(
+    public Long deleteReply (Long replyId){
+        Reply existingReply = checkReply(replyId);
+
+        replyRepository.deleteById(replyId);
+        return replyId;
+    }
+
+    //댓글 존재하는지 확인
+    public Reply checkReply (Long replyId){
+        Reply existingReply = replyRepository.findById(replyId).orElseThrow(
                 () -> new BusinessLogicException(ExceptionCode.REPLY_NOT_FOUND));
 
-        replyRepository.deleteById(id);
-        return id;
+        return existingReply;
     }
 }

--- a/src/main/java/greenjangtanji/yeosuro/user/entity/User.java
+++ b/src/main/java/greenjangtanji/yeosuro/user/entity/User.java
@@ -1,7 +1,6 @@
 package greenjangtanji.yeosuro.user.entity;
 
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import greenjangtanji.yeosuro.feed.entity.Feed;
 import greenjangtanji.yeosuro.image.entity.Image;
 import greenjangtanji.yeosuro.plan.entity.Plan;

--- a/src/main/java/greenjangtanji/yeosuro/user/service/UserService.java
+++ b/src/main/java/greenjangtanji/yeosuro/user/service/UserService.java
@@ -125,18 +125,6 @@ public class UserService {
         return null;
     }
 
-    //활성화 상태인 회원 확인
-    private User checkUser (Long userId){
-        User existingUser = userRepository.findById(userId).orElseThrow(
-                () -> new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
-
-        if (existingUser.getUserStatus() != UserStatus.ACTIVE) {
-            throw new BusinessLogicException(ExceptionCode.USER_NOT_ACTIVE);
-        }
-
-        return existingUser;
-    }
-
     //닉네님 중복확인
     private void checkNickname (String nickname){
         Optional<User> user = userRepository.findByNickname(nickname);
@@ -151,6 +139,18 @@ public class UserService {
         if (user.isPresent()){
             throw new BusinessLogicException(ExceptionCode.DUPLICATE_EMAIL_ERROR);
         }
+    }
+
+    //활성화 상태인 회원 확인
+    private User checkUser (Long userId){
+        User existingUser = userRepository.findById(userId).orElseThrow(
+                () -> new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
+
+        if (existingUser.getUserStatus() != UserStatus.ACTIVE) {
+            throw new BusinessLogicException(ExceptionCode.USER_NOT_ACTIVE);
+        }
+
+        return existingUser;
     }
 
     public Long extractUserId (Authentication authentication){


### PR DESCRIPTION
- 게시글 좋아요 생성, 취소 기능 
- 댓글 좋아요 생성, 취소 기능 
- 게시글/ 댓글 정보 조회 시 좋아요 갯수 출력 

위 기능 구현 완료했습니다. 
여정 후기, 게시글, 댓글 좋아요 테이블을 모두 따로 구현하기로 논의했던것을 바탕으로 작업했습니다. 
controller와 service는 한곳에서 작업해도 괜찮을것같아 클래스를 구분하지 않았고, entity와 repository는 3개 부분이 각각 구분해서 구현했습니다. 
